### PR TITLE
chore: 移除 Cargo 代理配置并重置全局配置，解决因为网络问题引起的 ci 失败

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,14 @@ jobs:
     container:
       image: duskmoon/dev-env:rcore-ci
     steps:
+      - name: Remove Cargo proxy config
+        run: |
+          unset RUSTUP_DIST_SERVER
+          unset RUSTUP_UPDATE_ROOT
+          unset CARGO_HTTP_MULTIPLEXING
+          # 删除或重置全局配置
+          rm ${CARGO_HOME}/config.toml || true
+          rm -rf rm ${CARGO_HOME}/registry/* || true
       - uses: actions/checkout@v4
       - name: Run tests
         run: |


### PR DESCRIPTION
# 提交这个 pr 的原因
- GitHub Actions 是在外网环境下进行的构建，而默认使用的 duskmoon/dev-env:rcore-ci 镜像，默认配置了 rsproxy.cn ，所以导致每次构建的时候都有很大的几率失败，分析研究了一下镜像内容，发现除了对应的环境变量，还需要把下面的配置文件和缓存删除才能保证下载包的时候不使用代理，通过这样的配置，可以确保不会出现因为网络问题引起的 ci 构建失败。例如 https://github.com/LearningOS/2025s-rcore-expoli/actions/runs/14425633222/job/40454057776#step:4:392 这种日志
```yaml
rm ${CARGO_HOME}/config.toml || true
rm -rf rm ${CARGO_HOME}/registry/* || true
```

```log
Caused by:
  process didn't exit successfully: `git fetch --force --update-head-ok 'https://rsproxy.cn/crates.io-index' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
    Updating `rsproxy` index
fatal: repository 'https://rsproxy.cn/crates.io-index/' not found
error: failed to get `bitflags` as a dependency of package `user_lib v0.1.0 (/__w/2025s-rcore-expoli/2025s-rcore-expoli/ci-user/user)`

Caused by:
  failed to load source for dependency `bitflags`

Caused by:
  Unable to update registry `crates-io`

Caused by:
  failed to update replaced source registry `crates-io`

Caused by:
  failed to fetch `[https://rsproxy.cn/crates.io-index`](https://rsproxy.cn/crates.io-index%60)

Caused by:
  process didn't exit successfully: `git fetch --force --update-head-ok 'https://rsproxy.cn/crates.io-index' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
    Updating `rsproxy` index
fatal: repository 'https://rsproxy.cn/crates.io-index/' not found
error: failed to get `bitflags` as a dependency of package `user_lib v0.1.0 (/__w/2025s-rcore-expoli/2025s-rcore-expoli/ci-user/user)`
```