### PR TITLE
chore: 移除 Cargo 代理配置并重置全局配置

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,14 @@ jobs:
     container:
       image: duskmoon/dev-env:rcore-ci
     steps:
+      - name: Remove Cargo proxy config
+        run: |
+          unset RUSTUP_DIST_SERVER
+          unset RUSTUP_UPDATE_ROOT
+          unset CARGO_HTTP_MULTIPLEXING
+          # 删除或重置全局配置
+          rm ${CARGO_HOME}/config.toml || true
+          rm -rf rm ${CARGO_HOME}/registry/* || true
       - uses: actions/checkout@v4
       - name: Run tests
         run: |


### PR DESCRIPTION
本 PR 受 @expoli 启发，删除 CI 镜像中关于 rustup 的代理配置。
具体原因见 PR https://github.com/LearningOS/os-rcore-classroom-2025s-rcore-rCore-Camp-Code-2025S/pull/8 。