### PR TITLE
chore: 提前安装 cargo-binutils 并确保使用最新 Rust 版本

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,22 @@ jobs:
           unset RUSTUP_UPDATE_ROOT
           unset CARGO_HTTP_MULTIPLEXING
           # 删除或重置全局配置
-          rm ${CARGO_HOME}/config.toml || true
-          rm -rf rm ${CARGO_HOME}/registry/* || true
+          rm -f ${CARGO_HOME}/config.toml || true
+          rm -rf ${CARGO_HOME}/registry/* || true
+      - name: Update Rust toolchain
+        run: |
+          rustup self update
+          rustup update nightly
+          rustup default nightly
+      - name: Install cargo-binutils
+        run: |
+          cargo install cargo-binutils
       - uses: actions/checkout@v4
+      - name: Print Cargo source info
+        run: |
+          echo "==== Print Cargo source info ===="
+          cargo search test -v || echo "cargo search failed"
+          echo "==== End Cargo source info ===="
       - name: Run tests
         run: |
           qemu-system-riscv64 --version


### PR DESCRIPTION
- 将 `cargo-binutils` 安装步骤移至 checkout 之前，使用宿主环境的最新 Rust 进行编译，避免项目锁定 1.80 时出现对 1.82+ 的兼容性问题  
- 修复 CI 中清理 Cargo 配置和 registry 的命令，增加 `-f` 选项并去除多余 `rm`，提升流程健壮性  

请审阅